### PR TITLE
Added placeholder forms to the basic items on the check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.blueearthcat'
-version = '1.0.0.0'
+version = '1.0.0.1'
 compileJava.options.encoding = 'UTF-8'
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/blueearthcat/dpbc/functions/DPBCFunction.java
+++ b/src/main/java/com/blueearthcat/dpbc/functions/DPBCFunction.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.darksoldier1404.dppc.api.essentials.MoneyAPI.hasEnoughMoney;
@@ -28,7 +29,16 @@ public class DPBCFunction {
     public static void init(){
         if (config.getItemStack("Settings.CheckItem") == null) {
             YamlConfiguration data = config;
-            data.set("Settings.CheckItem", new ItemStack(Material.PAPER));
+            ItemStack item = new ItemStack(Material.PAPER);
+            ItemMeta im = item.getItemMeta();
+            im.setDisplayName("§f<check_price>$ Check");
+            List<String> lore = new ArrayList<>();
+            lore.add("§7");
+            lore.add("§7<check_issuer>");
+            lore.add("§7<check_issue_date>");
+            im.setLore(lore);
+            item.setItemMeta(im);
+            data.set("Settings.CheckItem", item);
             plugin.data.setConfig(data);
             plugin.data.save();
         }

--- a/src/main/java/com/blueearthcat/dpbc/functions/DPBCFunction.java
+++ b/src/main/java/com/blueearthcat/dpbc/functions/DPBCFunction.java
@@ -65,12 +65,14 @@ public class DPBCFunction {
         DInventory inv = new DInventory(null, lang.get("config_setting_title"), 27, plugin);
         for (int i = 0; i < inv.getSize(); i++) {
             if (i == 12 || i == 14) continue;
-            inv.setItem(i, new ItemBuilder(new ItemStack(Material.BLACK_STAINED_GLASS_PANE))
-                    .setItemName("§r").build()
-            );
+            ItemStack item = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+            ItemMeta im = item.getItemMeta();
+            im.setDisplayName("§r");
+            item.setItemMeta(im);
+            inv.setItem(i, item);
         }
         ItemStack item = NBT.setStringTag(new ItemBuilder(new ItemStack(Material.GLASS_PANE))
-                .setItemName(lang.get("config_check_issuer") + lang.get("config_check_true"))
+                .setDisplayName(lang.get("config_check_issuer") + lang.get("config_check_true"))
                 .addLore("")
                 .addLore(lang.get("config_check_issuer_lore"))
                 .build(), "dpbc_checkIssuer", "true");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DP-BlankCheck
-version: 1.0.0.0
+version: 1.0.0.1
 main: com.blueearthcat.dpbc.BlankCheck
 api-version: 1.14
 authors: [ BlueEarthCat ]


### PR DESCRIPTION
When you first use this plugin, the default check items will be changed as follows: 

- Material : PAPER
- DisplayName: <check_price>$ Check
- Lores : 
 -> (blank)
 -> <check_issuer>
 -> <check_issue_date>

If you want to change this Item, you can use `/dpbc item`